### PR TITLE
🎨 Customize bash prompt for improved user experience

### DIFF
--- a/bash/.bash_profile
+++ b/bash/.bash_profile
@@ -56,7 +56,7 @@ __bash_prompt() {
 
   # $? is a special Bash variable that holds the exit status of the last command (0 = success, non-zero = failure).
   # Uses λ (lambda) as the prompt symbol, matching Cmder's visual style.
-  local userpart='`export XIT=$? \
+  local userpart='`XIT=$? \
     && [ "$XIT" -ne "0" ] && echo -n "\[\033[31m\]λ " || echo -n "\[\033[33m\]λ "`'
 
   # Use __git_ps1 (from git-prompt.sh) when available for richer git status:

--- a/bash/.bash_profile
+++ b/bash/.bash_profile
@@ -28,3 +28,36 @@ test -d "$XDG_CONFIG_HOME" || test ! -d "$APPDATA" || {
 # Sets GnuPG configuration files directory.
 # https://www.gnupg.org/documentation/manuals/gnupg/GPG-Configuration.html
 export GNUPGHOME="$XDG_CONFIG_HOME/gnupg"
+
+# Customize the bash prompt (PS1)
+__bash_prompt() {
+  local green='\[\033[32m\]'
+  local yellow='\[\033[33m\]'
+  local red='\[\033[31m\]'
+  local reset='\[\033[0m\]'
+
+  # $? is a special Bash variable that holds the exit status of the last command (0 = success, non-zero = failure).
+  local userpart='`export XIT=$? \
+    && [ "$XIT" -ne "0" ] && echo -n "\[\033[31m\]➜ " || echo -n "\[\033[0m\]➜ "`'
+
+  # local gitbranch='`\
+  #     if [ "$(git config --get devcontainers-theme.hide-status 2>/dev/null)" != 1 ] && [ "$(git config --get codespaces-theme.hide-status 2>/dev/null)" != 1 ]; then \
+  #         export BRANCH="$(git --no-optional-locks symbolic-ref --short HEAD 2>/dev/null || git --no-optional-locks rev-parse --short HEAD 2>/dev/null)"; \
+  #         if [ "${BRANCH:-}" != "" ]; then \
+  #             echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH:-}" \
+  #             && if [ "$(git config --get devcontainers-theme.show-dirty 2>/dev/null)" = 1 ] && \
+  #                 git --no-optional-locks ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
+  #                     echo -n " \[\033[1;33m\]✗"; \
+  #             fi \
+  #             && echo -n "\[\033[0;36m\]) "; \
+  #         fi; \
+  #     fi`'
+
+  # PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "
+  # Show current path on one line, then arrow on the next
+  PS1="${green}\w${reset}\n${userpart}${reset}"
+
+  unset -f __bash_prompt
+}
+__bash_prompt
+export PROMPT_DIRTRIM=4

--- a/bash/.bash_profile
+++ b/bash/.bash_profile
@@ -38,6 +38,7 @@ for __git_prompt_path in \
     "/usr/share/git-core/contrib/completion/git-prompt.sh"; do
   [ -f "$__git_prompt_path" ] && { . "$__git_prompt_path"; break; }
 done
+
 unset __git_prompt_path
 
 export GIT_PS1_SHOWDIRTYSTATE=1       # * unstaged, + staged
@@ -82,5 +83,11 @@ __bash_prompt() {
 
   unset -f __bash_prompt
 }
+
 __bash_prompt
 export PROMPT_DIRTRIM=4
+
+# Print a blank line before each prompt except the very first one.
+__bash_first_prompt=1
+
+PROMPT_COMMAND='[ -z "$__bash_first_prompt" ] && printf "\n" || unset __bash_first_prompt'

--- a/bash/.bash_profile
+++ b/bash/.bash_profile
@@ -29,33 +29,56 @@ test -d "$XDG_CONFIG_HOME" || test ! -d "$APPDATA" || {
 # https://www.gnupg.org/documentation/manuals/gnupg/GPG-Configuration.html
 export GNUPGHOME="$XDG_CONFIG_HOME/gnupg"
 
+# Source git-prompt.sh for rich __git_ps1 support.
+# Tries common locations for Git Bash (MSYS2) and Ubuntu/WSL.
+for __git_prompt_path in \
+    "$HOME/.config/git/git-prompt.sh" \
+    "/usr/share/git/completion/git-prompt.sh" \
+    "/usr/lib/git-core/git-sh-prompt" \
+    "/usr/share/git-core/contrib/completion/git-prompt.sh"; do
+  [ -f "$__git_prompt_path" ] && { . "$__git_prompt_path"; break; }
+done
+unset __git_prompt_path
+
+export GIT_PS1_SHOWDIRTYSTATE=1       # * unstaged, + staged
+export GIT_PS1_SHOWSTASHSTATE=1       # $ stashed changes
+export GIT_PS1_SHOWUNTRACKEDFILES=1   # % untracked files
+export GIT_PS1_SHOWUPSTREAM="auto"    # < behind, > ahead, <> diverged, = in sync
+
 # Customize the bash prompt (PS1)
 __bash_prompt() {
   local green='\[\033[32m\]'
   local yellow='\[\033[33m\]'
+  local cyan='\[\033[0;36m\]'
   local red='\[\033[31m\]'
   local reset='\[\033[0m\]'
 
   # $? is a special Bash variable that holds the exit status of the last command (0 = success, non-zero = failure).
+  # Uses λ (lambda) as the prompt symbol, matching Cmder's visual style.
   local userpart='`export XIT=$? \
-    && [ "$XIT" -ne "0" ] && echo -n "\[\033[31m\]➜ " || echo -n "\[\033[0m\]➜ "`'
+    && [ "$XIT" -ne "0" ] && echo -n "\[\033[31m\]λ " || echo -n "\[\033[33m\]λ "`'
 
-  # local gitbranch='`\
-  #     if [ "$(git config --get devcontainers-theme.hide-status 2>/dev/null)" != 1 ] && [ "$(git config --get codespaces-theme.hide-status 2>/dev/null)" != 1 ]; then \
-  #         export BRANCH="$(git --no-optional-locks symbolic-ref --short HEAD 2>/dev/null || git --no-optional-locks rev-parse --short HEAD 2>/dev/null)"; \
-  #         if [ "${BRANCH:-}" != "" ]; then \
-  #             echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH:-}" \
-  #             && if [ "$(git config --get devcontainers-theme.show-dirty 2>/dev/null)" = 1 ] && \
-  #                 git --no-optional-locks ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
-  #                     echo -n " \[\033[1;33m\]✗"; \
-  #             fi \
-  #             && echo -n "\[\033[0;36m\]) "; \
-  #         fi; \
-  #     fi`'
+  # Use __git_ps1 (from git-prompt.sh) when available for richer git status:
+  # Falls back to a simpler custom implementation otherwise.
+  local gitbranch
+  if declare -f __git_ps1 > /dev/null; then
+    gitbranch='\[\033[0;36m\]`__git_ps1 "(%s) "`\[\033[0m\]'
+  else
+    gitbranch='`\
+        export BRANCH="$(git --no-optional-locks symbolic-ref --short HEAD 2>/dev/null \
+            || git --no-optional-locks rev-parse --short HEAD 2>/dev/null)"; \
+        if [ "${BRANCH:-}" != "" ]; then \
+            echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
+            && if [ -n "$(git --no-optional-locks status --porcelain 2>/dev/null)" ]; then \
+                echo -n " \[\033[1;33m\]✗"; \
+            fi \
+            && echo -n "\[\033[0;36m\]) "; \
+        fi`'
+  fi
 
-  # PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "
-  # Show current path on one line, then arrow on the next
-  PS1="${green}\w${reset}\n${userpart}${reset}"
+  # Line 1: user@host path (git branch)
+  # Line 2: λ prompt symbol (yellow on success, red on error)
+  PS1="${green}\w${reset} ${gitbranch}\n${userpart}${reset}"
 
   unset -f __bash_prompt
 }

--- a/bash/.bash_profile
+++ b/bash/.bash_profile
@@ -77,7 +77,7 @@ __bash_prompt() {
         fi`'
   fi
 
-  # Line 1: user@host path (git branch)
+  # Line 1: working directory with optional git branch/status info
   # Line 2: λ prompt symbol (yellow on success, red on error)
   PS1="${green}\w${reset} ${gitbranch}\n${userpart}${reset}"
 

--- a/bash/README.md
+++ b/bash/README.md
@@ -12,7 +12,7 @@ experience on Windows and Linux alike.
 ## .bash_profile
 
 The `.bash_profile` is the primary configuration file for interactive Bash sessions. It handles environment variables, the `PS1` prompt,
-and sources supporting scripts. It's desined to be portable across diffrent enviroments, with conditional logic to improve unix tools on
+and sources supporting scripts. It's designed to be portable across diffrent enviroments, with conditional logic to improve unix tools on
 Windows.
 
 ### Prompt (PS1)

--- a/bash/README.md
+++ b/bash/README.md
@@ -1,0 +1,64 @@
+      _                 _
+     | |               | |
+     | |__   ___    ___| |__  _ __ ___
+     | '_ \ / _` \ / __| '_ \| '__/ __|
+    _| |_) | (_| |\__  \ | | | | | (__
+   (_)____.__/ \__,|___/_| |_|_|  \___|
+
+This Bash configuration is designed to work seamlessly across both Git Bash (MSYS2) and Ubuntu/WSL environments. It provides a clean,
+informative prompt inspired by [Cmder](https://cmderdev.github.io/cmder/), with rich git status integration and a consistent developer
+experience on Windows and Linux alike.
+
+## .bash_profile
+
+The `.bash_profile` is the primary configuration file for interactive Bash sessions. It handles environment variables, the `PS1` prompt,
+and sources supporting scripts. It's desined to be portable across diffrent enviroments, with conditional logic to improve unix tools on
+Windows.
+
+### Prompt (PS1)
+
+The prompt is a two-line layout inspired by [Cmder](https://cmderdev.github.io/cmder/):
+
+```bash
+~/projects/dotfiles (main *%)
+λ
+```
+
+- __Line 1__ — current working directory and git status (when inside a repository).
+- __Line 2__ — the `λ` prompt symbol, yellow on success and red on a non-zero exit code.
+
+#### Git Status
+
+Git information is provided by `__git_ps1`, a function shipped with Git itself via `git-prompt.sh`. The file is sourced automatically from
+the following locations, in order of preference:
+
+| Path                                                   | Environment         |
+|--------------------------------------------------------|---------------------|
+| `$HOME/.config/git/git-prompt.sh`                      | User override (any) |
+| `/usr/share/git/completion/git-prompt.sh`              | Git Bash / MSYS2    |
+| `/usr/lib/git-core/git-sh-prompt`                      | Ubuntu / Debian     |
+| `/usr/share/git-core/contrib/completion/git-prompt.sh` | Other distros       |
+
+When `git-prompt.sh` is found, the following indicators are enabled:
+
+| Variable                     | Symbol | Meaning                |
+|------------------------------|--------|------------------------|
+| `GIT_PS1_SHOWDIRTYSTATE`     | `*`    | Unstaged changes       |
+| `GIT_PS1_SHOWDIRTYSTATE`     | `+`    | Staged changes         |
+| `GIT_PS1_SHOWSTASHSTATE`     | `$`    | Stashed changes        |
+| `GIT_PS1_SHOWUNTRACKEDFILES` | `%`    | Untracked files        |
+| `GIT_PS1_SHOWUPSTREAM`       | `<`    | Behind upstream        |
+| `GIT_PS1_SHOWUPSTREAM`       | `>`    | Ahead of upstream      |
+| `GIT_PS1_SHOWUPSTREAM`       | `<>`   | Diverged from upstream |
+| `GIT_PS1_SHOWUPSTREAM`       | `=`    | In sync with upstream  |
+
+> [!NOTE]
+> If `git-prompt.sh` is not found, the prompt falls back to a simpler custom implementation that shows the branch name and a `✗` indicator
+> when there are uncommitted or untracked changes.
+
+## References
+
+- [Cmder — Console Emulator for Windows](https://cmderdev.github.io/cmder/)
+- [git-prompt.sh source (Git for Windows)](https://github.com/git-for-windows/git/blob/main/contrib/completion/git-prompt.sh)
+- [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+- [Bash Prompt HOWTO](https://tldp.org/HOWTO/Bash-Prompt-HOWTO/)


### PR DESCRIPTION
This pull request introduces a customized bash prompt to the `.bash_profile`, enhancing the user experience by providing visual cues and useful information directly in the terminal prompt.

## Bash prompt customization:

* Added a `__bash_prompt` function that sets the `PS1` variable to display the current working directory in green, followed by a colored arrow indicating the success or failure of the last command.
* Displaying the current **git branch** and **repository status** for additional context in the prompt.
* Set `PROMPT_DIRTRIM=4` to limit the length of the directory path shown in the prompt, keeping it concise.